### PR TITLE
Upstream maintenance update, alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,12 @@
 Provides an http4s client backend based on
 [async-http-client][async-http-client].
 
-## Deprecated
-
-The upstream client is [unmaintained][unmaintained].  Accordingly, the
-backend was deprecated in v0.22.12 and v0.23.11, and this repository is
-unmaintained by the http4s team.
+## Unmaintained
 
 If you are interested in reviving this backend, please reply to the
 [call for maintainers][call-for-maintainers].
 
+See the [backend integrations](https://http4s.org/v0.23/docs/integrations.html#backend-integrations) for some alternative clients.
+
 [async-http-client]: https://github.com/AsyncHttpClient/async-http-client
 [call-for-maintainers]: https://github.com/http4s/http4s-async-http-client/issues/6
-[unmaintained]: https://github.com/AsyncHttpClient/async-http-client/commit/c959fa0483adb4a71fbccc5be94d8b6faa4f74be


### PR DESCRIPTION
* The upstream has a new maintainer.  
* Like http4s-okhttp-client, link to some alternatives.