### PR TITLE
bump versions, adapt to Cats Effect 3.5.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: ['**']
+    branches: ['**', '!update/**', '!pr/**']
   push:
-    branches: ['**']
+    branches: ['**', '!update/**', '!pr/**']
     tags: [v*]
 
 env:
@@ -29,35 +29,35 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.15, 2.13.8, 3.1.2]
+        scala: [2.12.18, 2.13.11, 3.3.0]
         java: [temurin@8, temurin@11, temurin@17]
         exclude:
-          - scala: 2.12.15
+          - scala: 2.12.18
             java: temurin@11
-          - scala: 2.12.15
+          - scala: 2.12.18
             java: temurin@17
-          - scala: 3.1.2
+          - scala: 3.3.0
             java: temurin@11
-          - scala: 3.1.2
+          - scala: 3.3.0
             java: temurin@17
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Download Java (temurin@8)
         id: download-java-temurin-8
         if: matrix.java == 'temurin@8'
-        uses: typelevel/download-java@v1
+        uses: typelevel/download-java@v2
         with:
           distribution: temurin
           java-version: 8
 
       - name: Setup Java (temurin@8)
         if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: jdkfile
           java-version: 8
@@ -66,14 +66,14 @@ jobs:
       - name: Download Java (temurin@11)
         id: download-java-temurin-11
         if: matrix.java == 'temurin@11'
-        uses: typelevel/download-java@v1
+        uses: typelevel/download-java@v2
         with:
           distribution: temurin
           java-version: 11
 
       - name: Setup Java (temurin@11)
         if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: jdkfile
           java-version: 11
@@ -82,21 +82,21 @@ jobs:
       - name: Download Java (temurin@17)
         id: download-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: typelevel/download-java@v1
+        uses: typelevel/download-java@v2
         with:
           distribution: temurin
           java-version: 17
 
       - name: Setup Java (temurin@17)
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: jdkfile
           java-version: 17
           jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
 
       - name: Cache sbt
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.sbt
@@ -108,26 +108,30 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Check that workflows are up to date
-        run: sbt '++${{ matrix.scala }}' 'project /' githubWorkflowCheck
+        run: sbt githubWorkflowCheck
 
       - name: Check headers and formatting
-        if: matrix.java == 'temurin@8'
-        run: sbt '++${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
+        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
+        run: sbt '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: Test
-        run: sbt '++${{ matrix.scala }}' test
+        run: sbt '++ ${{ matrix.scala }}' test
 
       - name: Check binary compatibility
-        if: matrix.java == 'temurin@8'
-        run: sbt '++${{ matrix.scala }}' mimaReportBinaryIssues
+        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
+        run: sbt '++ ${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
-        if: matrix.java == 'temurin@8'
-        run: sbt '++${{ matrix.scala }}' doc
+        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
+        run: sbt '++ ${{ matrix.scala }}' doc
+
+      - name: Check scalafix lints
+        if: matrix.java == 'temurin@8' && !startsWith(matrix.scala, '3.')
+        run: sbt '++ ${{ matrix.scala }}' 'scalafixAll --check'
 
       - name: Check unused compile dependencies
         if: matrix.java == 'temurin@8'
-        run: sbt '++${{ matrix.scala }}' unusedCompileDependenciesTest
+        run: sbt '++ ${{ matrix.scala }}' unusedCompileDependenciesTest
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
@@ -139,7 +143,7 @@ jobs:
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}
           path: targets.tar
@@ -151,26 +155,25 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Download Java (temurin@8)
         id: download-java-temurin-8
         if: matrix.java == 'temurin@8'
-        uses: typelevel/download-java@v1
+        uses: typelevel/download-java@v2
         with:
           distribution: temurin
           java-version: 8
 
       - name: Setup Java (temurin@8)
         if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: jdkfile
           java-version: 8
@@ -179,14 +182,14 @@ jobs:
       - name: Download Java (temurin@11)
         id: download-java-temurin-11
         if: matrix.java == 'temurin@11'
-        uses: typelevel/download-java@v1
+        uses: typelevel/download-java@v2
         with:
           distribution: temurin
           java-version: 11
 
       - name: Setup Java (temurin@11)
         if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: jdkfile
           java-version: 11
@@ -195,21 +198,21 @@ jobs:
       - name: Download Java (temurin@17)
         id: download-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: typelevel/download-java@v1
+        uses: typelevel/download-java@v2
         with:
           distribution: temurin
           java-version: 17
 
       - name: Setup Java (temurin@17)
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: jdkfile
           java-version: 17
           jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
 
       - name: Cache sbt
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.sbt
@@ -220,52 +223,32 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (2.12.15)
-        uses: actions/download-artifact@v2
+      - name: Download target directories (2.12.18)
+        uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.15
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.18
 
-      - name: Inflate target directories (2.12.15)
+      - name: Inflate target directories (2.12.18)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13.8)
-        uses: actions/download-artifact@v2
+      - name: Download target directories (2.13.11)
+        uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.11
 
-      - name: Inflate target directories (2.13.8)
+      - name: Inflate target directories (2.13.11)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13.8)
-        uses: actions/download-artifact@v2
+      - name: Download target directories (3.3.0)
+        uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.3.0
 
-      - name: Inflate target directories (2.13.8)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (2.13.8)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8
-
-      - name: Inflate target directories (2.13.8)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (3.1.2)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.2
-
-      - name: Inflate target directories (3.1.2)
+      - name: Inflate target directories (3.3.0)
         run: |
           tar xf targets.tar
           rm targets.tar
@@ -282,4 +265,4 @@ jobs:
           (echo "$PGP_PASSPHRASE"; echo; echo) | gpg --command-fd 0 --pinentry-mode loopback --change-passphrase $(gpg --list-secret-keys --with-colons 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5 | tail -n 1)
 
       - name: Publish
-        run: sbt '++${{ matrix.scala }}' tlRelease
+        run: sbt tlCiRelease

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,3 @@
+rules = [
+  NoValInForComprehension
+]

--- a/async-http-client/src/main/scala/org/http4s/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/asynchttpclient/AsyncHttpClient.scala
@@ -64,7 +64,9 @@ object AsyncHttpClient {
           F.delay(
             httpClient
               .executeRequest(toAsyncRequest(req, dispatcher), asyncHandler(cb, dispatcher))
-          ).as(Some(F.unit))
+          ).map { future =>
+            Some(F.blocking(future.cancel(true)).void)
+          }
         })
       }
 

--- a/async-http-client/src/main/scala/org/http4s/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/asynchttpclient/AsyncHttpClient.scala
@@ -64,7 +64,7 @@ object AsyncHttpClient {
           F.delay(
             httpClient
               .executeRequest(toAsyncRequest(req, dispatcher), asyncHandler(cb, dispatcher))
-          ).as(None)
+          ).as(Some(F.unit))
         })
       }
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,20 +4,17 @@ ThisBuild / developers := List(
   tlGitHubDev("rossabaker", "Ross A. Baker")
 )
 
-val Scala213 = "2.13.8"
-ThisBuild / crossScalaVersions := Seq("2.12.15", Scala213, "3.1.2")
+val Scala213 = "2.13.11"
+ThisBuild / crossScalaVersions := Seq("2.12.18", Scala213, "3.3.0")
 ThisBuild / scalaVersion := Scala213
 
 lazy val root = project.in(file(".")).aggregate(asyncHttpClient).enablePlugins(NoPublishPlugin)
 
-val http4sVersion = "0.23.11"
+val http4sVersion = "0.23.22"
 val asyncHttpClientVersion = "2.12.3"
-val fs2Version = "3.2.7"
-val nettyVersion = "4.1.77.Final"
-val reactiveStreamsVersion = "1.0.3"
-
-ThisBuild / resolvers +=
-  "s01 snapshots".at("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+val fs2Version = "3.7.0"
+val nettyVersion = "4.1.94.Final"
+val reactiveStreamsVersion = "1.0.4"
 
 lazy val asyncHttpClient = project
   .in(file("async-http-client"))
@@ -32,6 +29,6 @@ lazy val asyncHttpClient = project
       "io.netty" % "netty-buffer" % nettyVersion,
       "io.netty" % "netty-codec-http" % nettyVersion,
       "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion,
-      "org.http4s" %% "http4s-client-testkit" % "0.23.11-473-e7e64cb-SNAPSHOT" % Test,
+      "org.http4s" %% "http4s-client-testkit" % http4sVersion % Test,
     ),
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.13.2")
+addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.14.13")


### PR DESCRIPTION
Not sure what else is needed. Opted for `Some(F.unit)` to keep the current semantics.

@armanbilge @rossabaker 

Before anyone asks, I'm not interested in maintaining it :sweat_smile:  This is a short-term fix while we plan to migrate to a different client backend.

Oh, and SLF4J spits out these lines, I'm actually not sure what caused it to start doing that...
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```